### PR TITLE
Simplify benchmark code

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@types/chai": "^4.1.2",
     "@types/mocha": "^5.0.0",
     "@types/node": "^9.6.2",
+    "benchmarkjs-pretty": "^2.0.0",
     "chai": "^4.1.2",
     "mocha": "^5.0.5",
     "rimraf": "^2.6.2",

--- a/src/comparison-test.ts
+++ b/src/comparison-test.ts
@@ -1,0 +1,35 @@
+import { bench } from "./index";
+import Benchmark from "benchmarkjs-pretty";
+
+export const delay = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+export async function perf() {
+  await bench("foo", () => 1 + 1);
+  await bench("foo2", () => 1 ** 1);
+  await bench("fibonacci", () => fibonacci(3));
+  await bench("foo3", () => delay(2));
+  await new Benchmark("pretty")
+    .add("foo", () => 1 + 1)
+    .add("foo2", () => 1 ** 1)
+    .add("fibonacci", () => fibonacci(3))
+    .add("foo3", () => delay(2))
+    .run();
+}
+
+perf();
+
+function fibonacci(num: number) {
+  let a = 1;
+  let b = 0;
+  let temp;
+
+  while (num >= 0) {
+    temp = a;
+    a = a + b;
+    b = temp;
+    num--;
+  }
+
+  return b;
+}

--- a/src/comparison-test.ts
+++ b/src/comparison-test.ts
@@ -7,12 +7,14 @@ export const delay = (ms: number) =>
 export async function perf() {
   await bench("foo", () => 1 + 1);
   await bench("foo2", () => 1 ** 1);
-  await bench("fibonacci", () => fibonacci(3));
+  await bench("fibonacci", () => fibonacci(10));
+  await bench("recfibonacci", () => recursiveFibonacci(10));
   await bench("foo3", () => delay(2));
   await new Benchmark("pretty")
     .add("foo", () => 1 + 1)
     .add("foo2", () => 1 ** 1)
-    .add("fibonacci", () => fibonacci(3))
+    .add("fibonacci", () => fibonacci(10))
+    .add("rec fibonacci", () => recursiveFibonacci(10))
     .add("foo3", () => delay(2))
     .run();
 }
@@ -32,4 +34,9 @@ function fibonacci(num: number) {
   }
 
   return b;
+}
+
+function recursiveFibonacci(n: number): number {
+  if (n === 1 || n === 2) return 1;
+  return recursiveFibonacci(n - 1) + recursiveFibonacci(n - 2);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,14 +24,7 @@ export interface Result {
 }
 
 export async function benchmark(name: string, fn: () => void): Promise<Result> {
-  let a = 0;
-  function noop() {
-    try {
-      a++;
-    } finally {
-      a += Math.random();
-    }
-  }
+  const noop = () => undefined;
 
   // warmup
   for (let i = 100; i--; ) noop(), await fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,9 +12,17 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/benchmark@^1.0.30":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/benchmark/-/benchmark-1.0.31.tgz#2dd3514e93396f362ba5551a7c9ff0da405c1d38"
+
 "@types/chai@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.2.tgz#f1af664769cfb50af805431c407425ed619daa21"
+
+"@types/chalk@^0.4.31":
+  version "0.4.31"
+  resolved "https://registry.yarnpkg.com/@types/chalk/-/chalk-0.4.31.tgz#a31d74241a6b1edbb973cf36d97a2896834a51f9"
 
 "@types/estree@*", "@types/estree@0.0.38":
   version "0.0.38"
@@ -96,6 +104,22 @@ balanced-match@^0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
+benchmarkjs-pretty@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/benchmarkjs-pretty/-/benchmarkjs-pretty-2.0.0.tgz#9f38c38141f9cfa5e06a37e0b0c05519b73bdae7"
+  dependencies:
+    "@types/benchmark" "^1.0.30"
+    "@types/chalk" "^0.4.31"
+    benchmark "^2.1.4"
+    chalk "^2.0.1"
+
 brace-expansion@^1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.7.tgz#3effc3c50e000531fb720eaff80f0ae8ef23cf59"
@@ -144,7 +168,7 @@ chalk@^1.1.0:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.0, chalk@^2.3.2:
+chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
@@ -445,6 +469,10 @@ locate-character@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/locate-character/-/locate-character-2.0.5.tgz#f2d2614d49820ecb3c92d80d193b8db755f74c0f"
 
+lodash@^4.17.4:
+  version "4.17.5"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
 magic-string@^0.22.4:
   version "0.22.5"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.5.tgz#8e9cf5afddf44385c1da5bc2a6a0dbd10b03657e"
@@ -559,6 +587,10 @@ pathval@^1.0.0:
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 plur@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
- Remove dead code that is jitted away by v8 immediately
- remove `setTimeout` call and use `await` directly
- Add test file to compare against `benchmark.js`